### PR TITLE
add port config to mgmt interface

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1258,23 +1258,49 @@ class DeviceMetaCfg(object):
 class MgmtIfaceCfg(object):
     """
     MgmtIfaceCfg Config Daemon
-    Handles changes in MGMT_INTERFACE, MGMT_VRF_CONFIG tables.
+    Handles changes in MGMT_INTERFACE, MGMT_VRF_CONFIG, MGMT_PORT tables.
     1) Handle change of interface ip
     2) Handle change of management VRF state
     """
+    # MGMT_PORT[port] keys which should not be cached, cause they have to be
+    # handled at startup of this daemon.
+    mgmt_port_handle_startup_keys = [
+        'arp-timeout',
+    ]
 
     def __init__(self):
         self.iface_config_data = {}
-        self.mgmt_vrf_enabled = ''
+        self.mgmt_vrf_enabled = None
+        self.port_config_data = {}
 
-    def load(self, mgmt_iface={}, mgmt_vrf={}):
-        # Get initial data
-        self.iface_config_data = mgmt_iface
-        self.mgmt_vrf_enabled = mgmt_vrf.get('mgmtVrfEnabled', '')
-        syslog.syslog(syslog.LOG_DEBUG,
-                      f'Initial mgmt interface conf: {self.iface_config_data}')
-        syslog.syslog(syslog.LOG_DEBUG,
-                      f'Initial mgmt VRF state: {self.mgmt_vrf_enabled}')
+    def load(self, iface_config, vrf_config, port_config):
+        syslog.syslog(syslog.LOG_DEBUG, 'MgmtIfaceCfg: Loading initial iface '
+                                        f'config: {iface_config}')
+        syslog.syslog(syslog.LOG_DEBUG, 'MgmtIfaceCfg: Loading initial vrf '
+                                        f'config: {vrf_config}')
+        syslog.syslog(syslog.LOG_DEBUG, 'MgmtIfaceCfg: Loading initial port '
+                                        f'config: {port_config}')
+        if not iface_config:
+            iface_config = {}
+        if not vrf_config:
+            vrf_config = {}
+        if not port_config:
+            port_config = {}
+
+        # Get iface config
+        self.iface_config_data = iface_config
+
+        # Get vrf config
+        self.mgmt_vrf_enabled = vrf_config.get('vrf_global', {}
+            ).get('mgmtVrfEnabled')
+
+        # Get port config.
+        # Remove all values that must be handled at daemon startup from cache.
+        self.port_config_data = port_config
+        for port in self.port_config_data:
+            for key in self.mgmt_port_handle_startup_keys:
+                self.port_config_data[port].pop(key, None)
+
 
     def update_mgmt_iface(self, iface, key, data):
         """Handle update management interface config
@@ -1295,6 +1321,31 @@ class MgmtIfaceCfg(object):
                 return
 
             self.iface_config_data[key] = data
+
+    def update_mgmt_port(self, iface, key, data):
+        """Handle update management interface config
+        """
+        syslog.syslog(syslog.LOG_DEBUG, 'MgmtIfaceCfg: mgmt port update')
+
+        # Get new configuration only
+        old_conf_set = set(self.port_config_data.get(key).items() if self.port_config_data.get(key) else {})
+        new_conf_set = set(data.items() if data else {})
+        diff_dict = dict(new_conf_set - old_conf_set)
+
+        syslog.syslog(syslog.LOG_INFO, f'MgmtIfaceCfg: Set new port config '
+                                       f'{diff_dict} for {iface}')
+        if {'admin_status', 'mtu', 'autoconf', 'dhcp-client-state', 'speed',
+            'duplex', 'autoneg'} & diff_dict.keys():
+            run_cmd(['sudo', 'systemctl', 'restart', 'interfaces-config'], True, True)
+
+        if {'arp-timeout'} & diff_dict.keys():
+            timeout = data.get('arp-timeout', None)
+
+            file_path = IPV4_ARP_TIMEOUT_PATH_FORMAT.format(iface)
+            with open(file_path, 'w+') as f:
+                f.write(timeout)
+
+        self.port_config_data[key] = data
 
     def update_mgmt_vrf(self, data):
         """Handle update management VRF state
@@ -1564,6 +1615,7 @@ class HostConfigDaemon:
         dev_meta = init_data.get(swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, {})
         mgmt_ifc = init_data.get(swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME, {})
         mgmt_vrf = init_data.get(swsscommon.CFG_MGMT_VRF_CONFIG_TABLE_NAME, {})
+        mgmt_port = init_data.get(swsscommon.CFG_MGMT_PORT_TABLE_NAME, {})
         syslog_cfg = init_data.get(swsscommon.CFG_SYSLOG_CONFIG_TABLE_NAME, {})
         syslog_srv = init_data.get(swsscommon.CFG_SYSLOG_SERVER_TABLE_NAME, {})
         dns = init_data.get('DNS_NAMESERVER', {})
@@ -1578,7 +1630,7 @@ class HostConfigDaemon:
         self.passwcfg.load(passwh)
         self.sshscfg.load(ssh_server)
         self.devmetacfg.load(dev_meta)
-        self.mgmtifacecfg.load(mgmt_ifc, mgmt_vrf)
+        self.mgmtifacecfg.load(mgmt_ifc, mgmt_vrf, mgmt_port)
 
         self.rsyslogcfg.load(syslog_cfg, syslog_srv)
         self.dnscfg.load(dns)
@@ -1641,6 +1693,11 @@ class HostConfigDaemon:
         self.aaacfg.handle_radius_source_intf_ip_chg(mgmt_intf_name)
         self.aaacfg.handle_radius_nas_ip_chg(mgmt_intf_name)
         self.mgmtifacecfg.update_mgmt_iface(mgmt_intf_name, key, data)
+
+    def mgmt_port_handler(self, key, op, data):
+        key = ConfigDBConnector.deserialize_key(key)
+        mgmt_intf_name = self.__get_intf_name(key)
+        self.mgmtifacecfg.update_mgmt_port(mgmt_intf_name, key, data)
 
     def mgmt_vrf_handler(self, key, op, data):
         self.mgmtifacecfg.update_mgmt_vrf(data)
@@ -1746,6 +1803,7 @@ class HostConfigDaemon:
         self.config_db.subscribe('LOOPBACK_INTERFACE', make_callback(self.lpbk_handler))
         # Handle updates to src intf changes in radius
         self.config_db.subscribe('MGMT_INTERFACE', make_callback(self.mgmt_intf_handler))
+        self.config_db.subscribe('MGMT_PORT', make_callback(self.mgmt_port_handler))
         self.config_db.subscribe('VLAN_INTERFACE', make_callback(self.vlan_intf_handler))
         self.config_db.subscribe('VLAN_SUB_INTERFACE', make_callback(self.vlan_sub_intf_handler))
         self.config_db.subscribe('PORTCHANNEL_INTERFACE', make_callback(self.portchannel_intf_handler))

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -247,7 +247,8 @@ class TestHostcfgdDaemon(TestCase):
         MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)
         MockConfigDb.event_queue = [
             (swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME, 'eth0|1.2.3.4/24'),
-            (swsscommon.CFG_MGMT_VRF_CONFIG_TABLE_NAME, 'vrf_global')
+            (swsscommon.CFG_MGMT_VRF_CONFIG_TABLE_NAME, 'vrf_global'),
+            (swsscommon.CFG_MGMT_PORT_TABLE_NAME, 'eth0')
         ]
         daemon = hostcfgd.HostConfigDaemon()
         daemon.register_callbacks()

--- a/tests/hostcfgd/test_vectors.py
+++ b/tests/hostcfgd/test_vectors.py
@@ -85,6 +85,13 @@ HOSTCFG_DAEMON_CFG_DB = {
             'mgmtVrfEnabled': 'true'
         }
     },
+    "MGMT_PORT": {
+        "eth0": {
+            'autoneg': 'on',
+            'duplex': 'full',
+            'speed': '1000'
+        }
+    },
     "DNS_NAMESERVER": {
         "1.1.1.1": {}
     },


### PR DESCRIPTION

#### Why I did it
Add the mgmt port configuration table which include the settings like port speed, duplex or auto-negotiation.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add "MGMT_PORT" table in sonic-swss-common submodule;
Add "MGMT_PORT" config handler for port settings in sonic-host-services;
Apply handler for port settings in interfaces-config.service.


#### How to verify it
Built an image
Flash it to the switch
Write "MGMT_PORT" table in config db

> $ redis-cli
> 127.0.0.1:6379> select 4
> 127.0.0.1:6379[4]> HSET MGMT_PORT|eth0 autoneg off speed 100 duplex full

Wait for 30 seconds and then
Check the configuration has been applied
The following lines included in syslog
```
INFO hostcfgd: MgmtIfaceCfg: Set new port config {'autoneg': 'off', 'duplex': 'full', 'speed': '100'} for eth0
INFO interfaces-config.sh[135372]: ethtool -s eth0 speed 100 duplex full autoneg off
```

Use ethtool to check the auto-negotiation is off and speed is 100Mb
```
$ ethtool eth0
Settings for eth0:
        Supported ports: [ TP ]
        Supported link modes:   10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
                                1000baseT/Full
        Supported pause frame use: Symmetric
        Supports auto-negotiation: Yes
        Supported FEC modes: Not reported
        Advertised link modes:  Not reported
        Advertised pause frame use: Symmetric
        Advertised auto-negotiation: No
        Advertised FEC modes: Not reported
        Speed: 100Mb/s
        Duplex: Full
        Auto-negotiation: off
        Port: Twisted Pair
        PHYAD: 1
        Transceiver: internal
        MDI-X: on (auto)
        Supports Wake-on: pumbg
        Wake-on: g
        Current message level: 0x00000007 (7)
                               drv probe link
        Link detected: yes
```

Save configuration by "config save" command
Check the following part in /etc/sonic/config_db.json
```
    "MGMT_PORT": {
        "eth0": {
            "autoneg": "off",
            "duplex": "full",
            "speed": "100"
        }
    },
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)